### PR TITLE
chore: instruct rustc to build a better binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,7 @@ codegen-units = 1
 panic = "abort"
 strip = true
 
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,6 @@ path = "src/main.rs"
 opt-level = 3
 lto = "fat"
 codegen-units = 1
+panic = "abort"
+strip = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,8 @@ http-body-util = "0.1.2"
 name = "horizon"
 path = "src/main.rs"
 
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+


### PR DESCRIPTION
This pull request aims to get rustc to create a better binary, and also includes a new build profile tailored for profiling.

# How

`opt-level = 3`
this is the default; it is basically -O3 in clang. you may want to knock this down to O2 to reduce binary sizes (and save ram, at the cost of possibly slower execution time)
`lto = "fat"`
enables "fat" lto, which can reduce binary size and improve runtime speed. see [this wikipedia article](https://en.wikipedia.org/wiki/Interprocedural_optimization) to learn more
`codegen-units = 1`
only use one codegen unit to allow LLVM to optimize better
`panic = "abort"`
don't unwind the stack on panic. this can improve performance and lower binary size (== less ram)
`strip = true`
this will remove debug info from the final executable, which can reduce compile times significantly under macos, and lower binary size under linux, but no effect on windows builds (because .pdb is a separate file)

note that this does not affect compilation time for `dev` builds, only release builds (which are triggered via `cargo b --release`)
