### PR TITLE
build: remove unused jemalloc dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "serde",
  "serde_json",
  "socketioxide",
- "tikv-jemallocator",
  "tokio",
  "tokio-console",
  "tracing",
@@ -2853,26 +2852,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,6 @@ nalgebra = "0.33.0"
 v = "0.1.0"
 rayon = "1.10.0"
 
-tikv-jemallocator = "0.5.4"
-
-
 [[bin]]
 name = "horizon"
 path = "src/main.rs"


### PR DESCRIPTION
someone merged both jemalloc and mimalloc branches 💀 

don't worry, it didn't break anything other than building under android, which I'm sure none of you guys are doing and probably shouldn't be doing.