### PR TITLE
build: remove useless build.rs file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "Horizon"
 version = "0.1.0"
 edition = "2021"
-build = "build.rs"
 
 [dependencies]
 axum = { version = "0.7.5", features = ["tokio", "http1"] }

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-  println!("Final Compiling...")
-}


### PR DESCRIPTION
println!s in build.rs dont show by default, and rust has to compile and execute this build script, which slows down compilation.